### PR TITLE
add "repository" field to package.json to avoid npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "scripts": {
     "test": "node_modules/.bin/mocha test/index.js"
   },
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mirkokiefer/canonical-json.git"
+  },
   "author": "Mirko Kiefer <mail@mirkokiefer.com>",
   "license": "BSD"
 }


### PR DESCRIPTION
```
$ npm install
npm WARN package.json canonical-json@0.0.3 No repository field.
```
