### PR TITLE
Canonical json with array fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,6 +119,7 @@ function str(key, holder) {
             for (i = 0; i < length; i += 1) {
                 partial[i] = str(i, value) || 'null';
             }
+            partial = partial.sort()
 
 // Join all of the elements together, separated with commas, and wrap them in
 // brackets.

--- a/test/index.js
+++ b/test/index.js
@@ -5,12 +5,12 @@ var testModule = function(moduleName) {
   describe('stringify in module ' + moduleName, function() {
     var stringify = require('../' + moduleName)
     it('should output objects with sorted keys', function() {
-      var object1 = [{a: 1, b: 2, c: 3, d: {c: 1, a: 2}}, 2]
-      var object2 = [{d: {a: 2, c: 1}, b: 2, a: 1, c: 3}, 2]
+      var object1 = [2, {a: 1, b: 2, c: 3, d: {c: 1, a: 2}}]
+      var object2 = [2, {d: {a: 2, c: 1}, b: 2, a: 1, c: 3}]
 
       var json1 = stringify(object1)
       var json2 = stringify(object2)
-      var expected = '[{"a":1,"b":2,"c":3,"d":{"a":2,"c":1}},2]'
+      var expected = '[2,{"a":1,"b":2,"c":3,"d":{"a":2,"c":1}}]'
       assert.deepEqual(json1, expected)
       assert.deepEqual(json2, expected)
     })


### PR DESCRIPTION
Currently `canonical-json` could produce different serializations when input object contains an array, for example:

``` js
jsStringify({foo: [1, 2, 3]}) // => '{"foo":[1,2,3]}'
jsStringify({foo: [3, 2, 1]}) // => '{"foo":[3,2,1]}'
```

I foxed it by sorting all arrays with native `Array.prototype.sort()` method.

**P.S.:** I tried to add a test case, but it broke tests for `index2.js`.
Oh, and I only tested it in node.
